### PR TITLE
add unittest base class for testing database

### DIFF
--- a/gestion_base_adresse/test/database_test.py
+++ b/gestion_base_adresse/test/database_test.py
@@ -1,0 +1,58 @@
+"""Base class for tests using a database with data."""
+
+import psycopg2
+
+from qgis.core import (
+    QgsApplication,
+    Qgis,
+)
+from qgis.testing import unittest
+
+if Qgis.QGIS_VERSION_INT >= 30800:
+    from qgis import processing
+else:
+    import processing
+
+from ..processing.provider import GestionAdresseProvider
+from ..qgis_plugin_tools.tools.logger_processing import LoggerProcessingFeedBack
+
+__copyright__ = 'Copyright 2019, 3Liz'
+__license__ = 'GPL version 3'
+__email__ = 'info@3liz.org'
+__revision__ = '$Format:%H$'
+
+
+
+class DatabaseTestCase(unittest.TestCase):
+
+    """Base class for tests using a database with data."""
+
+    def setUp(self) -> None:
+        self.connection = psycopg2.connect(
+            user='docker',
+            password='docker',
+            host='db',
+            port='5432',
+            database='gis'
+        )
+        self.cursor = self.connection.cursor()
+
+        self.provider = GestionAdresseProvider()
+        QgsApplication.processingRegistry().addProvider(self.provider)
+
+        self.feedback = LoggerProcessingFeedBack()
+
+        params = {
+            'CONNECTION_NAME': 'test',
+            'OVERRIDE': True,
+            'ADDTESTDATA': True,
+        }
+        processing.run('gestion_adresse:create_database_structure', params, feedback=None)
+
+        params = {
+            'CONNECTION_NAME': 'test',
+            'RUNIT': True,
+        }
+        processing.run('gestion_adresse:upgrade_database_structure', params, feedback=None)
+
+        super().setUp()

--- a/gestion_base_adresse/test/test_load_structure_new_db.py
+++ b/gestion_base_adresse/test/test_load_structure_new_db.py
@@ -1,0 +1,27 @@
+"""Tests for load structure with an empty database."""
+
+from .database_test import DatabaseTestCase
+
+__copyright__ = 'Copyright 2019, 3Liz'
+__license__ = 'GPL version 3'
+__email__ = 'info@3liz.org'
+__revision__ = '$Format:%H$'
+
+
+
+class TestLoadStructureEmptyDatabase(DatabaseTestCase):
+
+    """This class is redundant with test_load_structure,
+    but this one is using a setup function."""
+
+    def test_configure_project_with_new_db(self):
+        """Test we can load the PostGIS structure using the setup function."""
+
+        self.cursor.execute('SELECT table_name FROM information_schema.tables WHERE table_schema = \'adresse\'')
+        records = self.cursor.fetchall()
+        result = [r[0] for r in records]
+        expected = [
+            'appartenir_com', 'commune', 'document', 'metadata', 'point_adresse',
+            'voie', 'parcelle', 'commune_deleguee', 'referencer_com',
+        ]
+        self.assertCountEqual(expected, result)


### PR DESCRIPTION
In tests using this new base class `DatabaseTestCase`, a new database is setup before each test.

Follow the example in the last file