### PR TITLE
Fix SQL: utilisation d'idvoie dans les fonctions calcul_num

### DIFF
--- a/gestion_base_adresse/install/sql/adresse/10_FUNCTION.sql
+++ b/gestion_base_adresse/install/sql/adresse/10_FUNCTION.sql
@@ -347,7 +347,8 @@ BEGIN
         END IF;
         RETURN NEW;
     ELSIF (TG_TABLE_NAME = 'point_adresse') THEN
-        IF NEW.numero != OLD.numero OR NEW.suffixe != OLD.suffixe OR NEW.id_voie != OLD.id_voie THEN
+        -- Cas des différence
+        IF NEW.numero != OLD.numero OR NEW.suffixe IS DISTINCT FROM OLD.suffixe OR NEW.id_voie IS DISTINCT FROM OLD.id_voie THEN
             -- Cas où id_voie est null, calculer un nouvel id_voie
             IF NEW.id_voie IS NULL THEN
                 SELECT adresse.get_id_voie(NEW.geom) into idvoie;
@@ -357,6 +358,7 @@ BEGIN
                 END IF;
                 NEW.id_voie = idvoie;
             END IF;
+            -- Récupération nom complet de la voie
             SELECT nom_complet into adrvoie FROM adresse.voie WHERE id_voie = NEW.id_voie;
             IF NEW.suffixe IS NOT NULL THEN
                 NEW.adresse_complete = CONCAT(NEW.numero, ' ', NEW.suffixe, ' ', adrvoie);

--- a/gestion_base_adresse/install/sql/adresse/10_FUNCTION.sql
+++ b/gestion_base_adresse/install/sql/adresse/10_FUNCTION.sql
@@ -34,10 +34,7 @@ DECLARE
 BEGIN
 
     -- Get idvoie
-    SELECT id_voie into idvoie
-    FROM( SELECT id_voie, ST_Distance(pgeom, geom) as dist
-    FROM adresse.voie
-    WHERE statut_voie_num IS FALSE ORDER BY dist LIMIT 1) AS d;
+    SELECT adresse.get_id_voie(pgeom) into idvoie;
 
     SELECT adresse.calcul_point_position(adresse.calcul_segment_proche(geom, pgeom),pgeom ) into isleft
     FROM adresse.voie
@@ -129,10 +126,9 @@ CREATE FUNCTION adresse.calcul_num_metrique(pgeom public.geometry) RETURNS TABLE
     test boolean;
     suff text[];
 BEGIN
-    SELECT id_voie into idvoie FROM(
-    SELECT id_voie, ST_Distance(pgeom, geom) as dist
-    FROM adresse.voie
-    WHERE statut_voie_num IS FALSE ORDER BY dist LIMIT 1) AS d;
+
+    -- Get idvoie
+    SELECT adresse.get_id_voie(pgeom) into idvoie;
 
     SELECT v.sens_numerotation into sens FROM adresse.voie v WHERE v.id_voie = idvoie;
 

--- a/gestion_base_adresse/install/sql/adresse/10_FUNCTION.sql
+++ b/gestion_base_adresse/install/sql/adresse/10_FUNCTION.sql
@@ -50,7 +50,7 @@ BEGIN
     FROM(
     SELECT ST_Distance(pgeom, p1.geom) as dist, p1.numero as numero
     FROM adresse.point_adresse p1, adresse.voie v
-    WHERE statut_voie_num IS FALSE AND p1.id_voie = idvoie AND
+    WHERE statut_voie_num IS FALSE AND p1.id_voie = idvoie AND v.id_voie = idvoie AND
         (ST_LineLocatePoint(v.geom, ST_ClosestPoint(v.geom, pgeom)) - ST_LineLocatePoint(v.geom, ST_ClosestPoint(v.geom, p1.geom))) >0
         AND
         isleft =
@@ -63,7 +63,7 @@ BEGIN
     FROM(
     SELECT ST_Distance(pgeom, p1.geom) as dist, p1.numero as numero
     FROM adresse.point_adresse p1, adresse.voie v
-    WHERE statut_voie_num IS FALSE AND p1.id_voie = idvoie AND
+    WHERE statut_voie_num IS FALSE AND p1.id_voie = idvoie AND v.id_voie = idvoie AND
         (ST_LineLocatePoint(v.geom, ST_ClosestPoint(v.geom, pgeom)) - ST_LineLocatePoint(v.geom, ST_ClosestPoint(v.geom, p1.geom))) <0
         AND
         isleft =
@@ -137,10 +137,8 @@ BEGIN
     SELECT v.sens_numerotation into sens FROM adresse.voie v WHERE v.id_voie = idvoie;
 
     SELECT adresse.calcul_point_position(adresse.calcul_segment_proche(geom, pgeom),pgeom) into isleft
-    FROM( SELECT geom, id_voie, ST_Distance(pgeom, geom) as dist
     FROM adresse.voie
-    WHERE statut_voie_num IS FALSE ORDER BY dist LIMIT 1) AS d;
-
+    WHERE statut_voie_num IS FALSE AND id_voie = idvoie;
 
     SELECT round(ST_Length(v.geom)*ST_LineLocatePoint(v.geom, pgeom))::integer into num
     FROM adresse.voie v

--- a/gestion_base_adresse/install/sql/adresse/10_FUNCTION.sql
+++ b/gestion_base_adresse/install/sql/adresse/10_FUNCTION.sql
@@ -346,8 +346,8 @@ BEGIN
         END IF;
         RETURN NEW;
     ELSIF (TG_TABLE_NAME = 'point_adresse') THEN
-        IF NEW.numero != OLD.numero OR NEW.suffixe != OLD.suffixe THEN
-            SELECT nom_complet into adrvoie FROM adresse.voie WHERE id_voie = OLD.id_voie;
+        IF NEW.numero != OLD.numero OR NEW.suffixe != OLD.suffixe OR NEW.id_voie != OLD.id_voie THEN
+            SELECT nom_complet into adrvoie FROM adresse.voie WHERE id_voie = NEW.id_voie;
             IF NEW.suffixe IS NOT NULL THEN
                 NEW.adresse_complete = CONCAT(NEW.numero, ' ', NEW.suffixe, ' ', adrvoie);
             ELSE

--- a/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
+++ b/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
@@ -157,7 +157,7 @@ $$;
 
 
 -- update_adr_complete()
-CREATE FUNCTION adresse.update_adr_complete() RETURNS trigger
+CREATE OR REPLACE FUNCTION adresse.update_adr_complete() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 DECLARE

--- a/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
+++ b/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
@@ -172,7 +172,8 @@ BEGIN
         END IF;
         RETURN NEW;
     ELSIF (TG_TABLE_NAME = 'point_adresse') THEN
-        IF NEW.numero != OLD.numero OR NEW.suffixe != OLD.suffixe OR NEW.id_voie != OLD.id_voie THEN
+        -- Cas des différence
+        IF NEW.numero != OLD.numero OR NEW.suffixe IS DISTINCT FROM OLD.suffixe OR NEW.id_voie IS DISTINCT FROM OLD.id_voie THEN
             -- Cas où id_voie est null, calculer un nouvel id_voie
             IF NEW.id_voie IS NULL THEN
                 SELECT adresse.get_id_voie(NEW.geom) into idvoie;
@@ -182,6 +183,7 @@ BEGIN
                 END IF;
                 NEW.id_voie = idvoie;
             END IF;
+            -- Récupération nom complet de la voie
             SELECT nom_complet into adrvoie FROM adresse.voie WHERE id_voie = NEW.id_voie;
             IF NEW.suffixe IS NOT NULL THEN
                 NEW.adresse_complete = CONCAT(NEW.numero, ' ', NEW.suffixe, ' ', adrvoie);

--- a/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
+++ b/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
@@ -1,0 +1,162 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION adresse.calcul_num_adr(pgeom public.geometry) RETURNS TABLE(num integer, suffixe text)
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    numa integer;
+    numb integer;
+    numc integer;
+    sens boolean;
+    s text;
+    rec text;
+    suff text[];
+    idvoie integer;
+    isleft boolean;
+    test boolean;
+BEGIN
+
+    -- Get idvoie
+    SELECT id_voie into idvoie
+    FROM( SELECT id_voie, ST_Distance(pgeom, geom) as dist
+    FROM adresse.voie
+    WHERE statut_voie_num IS FALSE ORDER BY dist LIMIT 1) AS d;
+
+    SELECT adresse.calcul_point_position(adresse.calcul_segment_proche(geom, pgeom),pgeom ) into isleft
+    FROM adresse.voie
+    WHERE statut_voie_num IS FALSE AND id_voie=idvoie;
+
+    SELECT v.sens_numerotation into sens
+    FROM adresse.voie v WHERE v.id_voie = idvoie;
+
+    SELECT numero into numa
+    FROM(
+    SELECT ST_Distance(pgeom, p1.geom) as dist, p1.numero as numero
+    FROM adresse.point_adresse p1, adresse.voie v
+    WHERE statut_voie_num IS FALSE AND p1.id_voie = idvoie AND v.id_voie = idvoie AND
+        (ST_LineLocatePoint(v.geom, ST_ClosestPoint(v.geom, pgeom)) - ST_LineLocatePoint(v.geom, ST_ClosestPoint(v.geom, p1.geom))) >0
+        AND
+        isleft =
+        adresse.calcul_point_position(adresse.calcul_segment_proche(v.geom, p1.geom), p1.geom)
+    ORDER BY dist LIMIT 1) AS a;
+
+    suff = ARRAY ['bis', 'ter', 'qua', 'qui', 'a', 'b', 'c', 'd', 'e'];
+
+    SELECT numero into numb
+    FROM(
+    SELECT ST_Distance(pgeom, p1.geom) as dist, p1.numero as numero
+    FROM adresse.point_adresse p1, adresse.voie v
+    WHERE statut_voie_num IS FALSE AND p1.id_voie = idvoie AND v.id_voie = idvoie AND
+        (ST_LineLocatePoint(v.geom, ST_ClosestPoint(v.geom, pgeom)) - ST_LineLocatePoint(v.geom, ST_ClosestPoint(v.geom, p1.geom))) <0
+        AND
+        isleft =
+        adresse.calcul_point_position(adresse.calcul_segment_proche(v.geom, p1.geom), p1.geom)
+    ORDER BY dist LIMIT 1) AS b;
+
+    IF numa IS NOT NULL AND numb IS NOT NULL THEN
+        test = false;
+        IF numb - numa > 2 THEN
+         numc = numa+2;
+        ELSE
+            FOREACH rec IN ARRAY suff LOOP
+                IF (SELECT TRUE FROM adresse.point_adresse p WHERE p.id_voie = idvoie AND p.numero = numa AND p.suffixe = rec) IS NULL AND NOT test THEN
+                    test = true;
+                    numc = numa;
+                    s = rec;
+                END IF;
+            END LOOP;
+        END IF;
+    ELSIF numa IS NOT NULL AND numb IS NULL THEN
+        numc = numa+2;
+    ELSIF numa IS NULL AND numb IS NOT NULL THEN
+        IF numb - 2 >0 THEN
+            numc =  numb - 2;
+        ELSIF numb - 2 <= 0 THEN
+            test = false;
+            FOREACH rec IN ARRAY suff LOOP
+                IF (SELECT TRUE FROM adresse.point_adresse p WHERE p.id_voie = idvoie AND p.numero = numb AND p.suffixe = rec) IS NULL AND NOT test THEN
+                    test = true;
+                    numc = numb;
+                    s = rec;
+                END IF;
+            END LOOP;
+        END IF;
+    ELSIF numa IS NULL AND numb IS NULL THEN
+        IF isleft AND NOT sens THEN
+            numc = 1;
+        ELSIF NOT isleft AND NOT sens THEN
+            numc = 2;
+        ELSIF isleft AND sens THEN
+            numc = 2;
+        ELSIF NOT isleft AND sens THEN
+            numc = 1;
+        END IF;
+    END IF;
+
+    return query SELECT numc, s;
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION adresse.calcul_num_metrique(pgeom public.geometry) RETURNS TABLE(num integer, suffixe text)
+    LANGUAGE plpgsql
+    AS $$DECLARE
+    num integer;
+    idvoie integer;
+    numc integer;
+    sens boolean;
+    res text;
+    rec text;
+    isleft boolean;
+    test boolean;
+    suff text[];
+BEGIN
+    SELECT id_voie into idvoie FROM(
+    SELECT id_voie, ST_Distance(pgeom, geom) as dist
+    FROM adresse.voie
+    WHERE statut_voie_num IS FALSE ORDER BY dist LIMIT 1) AS d;
+
+    SELECT v.sens_numerotation into sens FROM adresse.voie v WHERE v.id_voie = idvoie;
+
+    SELECT adresse.calcul_point_position(adresse.calcul_segment_proche(geom, pgeom),pgeom) into isleft
+    FROM adresse.voie
+    WHERE statut_voie_num IS FALSE AND id_voie = idvoie;
+
+    SELECT round(ST_Length(v.geom)*ST_LineLocatePoint(v.geom, pgeom))::integer into num
+    FROM adresse.voie v
+    WHERE id_voie = idvoie;
+
+    suff = ARRAY ['bis', 'ter', 'qua', 'qui', 'a', 'b', 'c', 'd', 'e'];
+
+    IF isleft AND num%2 = 0 AND NOT sens THEN
+        num = num +1;
+    ELSIF NOT isleft AND num%2 != 0 AND NOT sens THEN
+        num = num + 1;
+    ELSIF isleft AND num%2 != 0 AND sens THEN
+        num = num +1;
+    ELSIF NOT isleft AND num%2 = 0 AND sens THEN
+        num = num + 1;
+    END IF;
+
+    test = false;
+    WHILE NOT test LOOP
+        IF (SELECT TRUE FROM adresse.point_adresse p WHERE p.id_voie = idvoie AND numero = num) IS NULL THEN
+            test = true;
+            numc = num;
+        ELSE
+            FOREACH rec IN ARRAY suff LOOP
+                IF (SELECT TRUE FROM adresse.point_adresse p WHERE p.id_voie = idvoie AND p.numero = num AND p.suffixe = rec) IS NULL AND NOT test THEN
+                    test = true;
+                    numc = num;
+                    res = rec;
+                END IF;
+            END LOOP;
+        END IF;
+        num = num +2;
+    END LOOP;
+
+   RETURN query SELECT numc, res;
+END;
+$$;
+
+COMMIT;

--- a/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
+++ b/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
@@ -17,10 +17,7 @@ DECLARE
 BEGIN
 
     -- Get idvoie
-    SELECT id_voie into idvoie
-    FROM( SELECT id_voie, ST_Distance(pgeom, geom) as dist
-    FROM adresse.voie
-    WHERE statut_voie_num IS FALSE ORDER BY dist LIMIT 1) AS d;
+    SELECT adresse.get_id_voie(pgeom) into idvoie;
 
     SELECT adresse.calcul_point_position(adresse.calcul_segment_proche(geom, pgeom),pgeom ) into isleft
     FROM adresse.voie
@@ -111,10 +108,9 @@ CREATE OR REPLACE FUNCTION adresse.calcul_num_metrique(pgeom public.geometry) RE
     test boolean;
     suff text[];
 BEGIN
-    SELECT id_voie into idvoie FROM(
-    SELECT id_voie, ST_Distance(pgeom, geom) as dist
-    FROM adresse.voie
-    WHERE statut_voie_num IS FALSE ORDER BY dist LIMIT 1) AS d;
+
+    -- Get idvoie
+    SELECT adresse.get_id_voie(pgeom) into idvoie;
 
     SELECT v.sens_numerotation into sens FROM adresse.voie v WHERE v.id_voie = idvoie;
 

--- a/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
+++ b/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
@@ -161,6 +161,7 @@ CREATE FUNCTION adresse.update_adr_complete() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 DECLARE
+    idvoie integer;
     adrvoie text;
 BEGIN
     IF (TG_TABLE_NAME = 'voie') THEN
@@ -172,6 +173,15 @@ BEGIN
         RETURN NEW;
     ELSIF (TG_TABLE_NAME = 'point_adresse') THEN
         IF NEW.numero != OLD.numero OR NEW.suffixe != OLD.suffixe OR NEW.id_voie != OLD.id_voie THEN
+            -- Cas où id_voie est null, calculer un nouvel id_voie
+            IF NEW.id_voie IS NULL THEN
+                SELECT adresse.get_id_voie(NEW.geom) into idvoie;
+                -- Aucune voie dévérouillée trouvée
+                IF idvoie IS NULL THEN
+                    return NULL;
+                END IF;
+                NEW.id_voie = idvoie;
+            END IF;
             SELECT nom_complet into adrvoie FROM adresse.voie WHERE id_voie = NEW.id_voie;
             IF NEW.suffixe IS NOT NULL THEN
                 NEW.adresse_complete = CONCAT(NEW.numero, ' ', NEW.suffixe, ' ', adrvoie);

--- a/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
+++ b/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
@@ -155,4 +155,34 @@ BEGIN
 END;
 $$;
 
+
+-- update_adr_complete()
+CREATE FUNCTION adresse.update_adr_complete() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    adrvoie text;
+BEGIN
+    IF (TG_TABLE_NAME = 'voie') THEN
+        IF NEW.typologie != OLD.typologie OR NEW.nom != OLD.nom THEN
+            UPDATE adresse.point_adresse
+            SET adresse_complete = CONCAT(numero, ' ', NEW.typologie, ' ', NEW.nom)
+            WHERE id_voie = OLD.id_voie;
+        END IF;
+        RETURN NEW;
+    ELSIF (TG_TABLE_NAME = 'point_adresse') THEN
+        IF NEW.numero != OLD.numero OR NEW.suffixe != OLD.suffixe OR NEW.id_voie != OLD.id_voie THEN
+            SELECT nom_complet into adrvoie FROM adresse.voie WHERE id_voie = NEW.id_voie;
+            IF NEW.suffixe IS NOT NULL THEN
+                NEW.adresse_complete = CONCAT(NEW.numero, ' ', NEW.suffixe, ' ', adrvoie);
+            ELSE
+                NEW.adresse_complete = CONCAT(NEW.numero, ' ', adrvoie);
+            END IF;
+        END IF;
+        RETURN NEW;
+    END IF;
+    RETURN NULL;
+END;
+$$;
+
 COMMIT;

--- a/gestion_base_adresse/test/test_execute_functions.py
+++ b/gestion_base_adresse/test/test_execute_functions.py
@@ -480,6 +480,62 @@ class TestSqlFunctions(DatabaseTestCase):
         self.cursor.execute(sql)
         self.assertTupleEqual(("1 Chemin des Cauterets",), self.cursor.fetchone())
 
+        # Modification du suffixe du point
+        sql = (
+            "UPDATE adresse.point_adresse SET suffixe = 'bis' WHERE id_point=1"
+        )
+        self.cursor.execute(sql)
+
+        sql = (
+            "select id_point, numero, suffixe, id_voie from adresse.point_adresse LIMIT 1"
+        )
+        self.cursor.execute(sql)
+        self.assertTupleEqual((1, 1, 'bis', 2), self.cursor.fetchone())
+
+        # Vérification du nom complet
+        sql = (
+            "select adresse_complete from adresse.point_adresse WHERE id_point=1"
+        )
+        self.cursor.execute(sql)
+        self.assertTupleEqual(("1 bis Chemin des Cauterets",), self.cursor.fetchone())
+        # Modification du suffixe du point
+        sql = (
+            "UPDATE adresse.point_adresse SET suffixe = 'ter' WHERE id_point=1"
+        )
+        self.cursor.execute(sql)
+
+        sql = (
+            "select id_point, numero, suffixe, id_voie from adresse.point_adresse LIMIT 1"
+        )
+        self.cursor.execute(sql)
+        self.assertTupleEqual((1, 1, 'ter', 2), self.cursor.fetchone())
+
+        # Vérification du nom complet
+        sql = (
+            "select adresse_complete from adresse.point_adresse WHERE id_point=1"
+        )
+        self.cursor.execute(sql)
+        self.assertTupleEqual(("1 ter Chemin des Cauterets",), self.cursor.fetchone())
+
+        # Modification du suffixe du point
+        sql = (
+            "UPDATE adresse.point_adresse SET numero = 3, suffixe = NULL WHERE id_point=1"
+        )
+        self.cursor.execute(sql)
+
+        sql = (
+            "select id_point, numero, suffixe, id_voie from adresse.point_adresse LIMIT 1"
+        )
+        self.cursor.execute(sql)
+        self.assertTupleEqual((1, 3, None, 2), self.cursor.fetchone())
+
+        # Vérification du nom complet
+        sql = (
+            "select adresse_complete from adresse.point_adresse WHERE id_point=1"
+        )
+        self.cursor.execute(sql)
+        self.assertTupleEqual(("3 Chemin des Cauterets",), self.cursor.fetchone())
+
     def test_calcul_num_adr_voie_complexe(self):
         """
         Test de la numérotation sur une voie complexe

--- a/gestion_base_adresse/test/test_execute_functions.py
+++ b/gestion_base_adresse/test/test_execute_functions.py
@@ -250,10 +250,10 @@ class TestSqlFunctions(DatabaseTestCase):
         sql = "TRUNCATE TABLE adresse.point_adresse RESTART IDENTITY"
         self.cursor.execute(sql)
 
-        sql='UPDATE adresse.voie SET statut_voie_num = true where id_voie = 1'
+        sql='UPDATE adresse.voie SET statut_voie_num = false where id_voie = 1'
         self.cursor.execute(sql)
 
-        sql='UPDATE adresse.voie SET statut_voie_num = true where id_voie = 2'
+        sql='UPDATE adresse.voie SET statut_voie_num = false where id_voie = 2'
         self.cursor.execute(sql)
 
         # Test ajout point impair

--- a/gestion_base_adresse/test/test_execute_functions.py
+++ b/gestion_base_adresse/test/test_execute_functions.py
@@ -435,3 +435,47 @@ class TestSqlFunctions(DatabaseTestCase):
         )
         self.cursor.execute(sql)
         self.assertTupleEqual(("1 Chemin des Cauterets",), self.cursor.fetchone())
+
+        # Modification de l'id_voie du point en mettant NULL
+        # seul la voie 3 est dévérouillé
+        sql = (
+            "UPDATE adresse.point_adresse SET id_voie = NULL WHERE id_point=1"
+        )
+        self.cursor.execute(sql)
+
+        sql = (
+            "select id_point, numero, suffixe, id_voie from adresse.point_adresse LIMIT 1"
+        )
+        self.cursor.execute(sql)
+        self.assertTupleEqual((1, 1, None, 3), self.cursor.fetchone())
+
+        # Vérification du nom complet
+        sql = (
+            "select adresse_complete from adresse.point_adresse WHERE id_point=1"
+        )
+        self.cursor.execute(sql)
+        self.assertTupleEqual(("1 Route d'Arromanches",), self.cursor.fetchone())
+
+        # Dévérouillage de la voie 2
+        sql='UPDATE adresse.voie SET statut_voie_num = false where id_voie = 2'
+        self.cursor.execute(sql)
+
+        # Modification de l'id_voie du point en mettant NULL
+        # la voie dévérouillée la plus proche est la 2
+        sql = (
+            "UPDATE adresse.point_adresse SET id_voie = NULL WHERE id_point=1"
+        )
+        self.cursor.execute(sql)
+
+        sql = (
+            "select id_point, numero, suffixe, id_voie from adresse.point_adresse LIMIT 1"
+        )
+        self.cursor.execute(sql)
+        self.assertTupleEqual((1, 1, None, 2), self.cursor.fetchone())
+
+        # Vérification du nom complet
+        sql = (
+            "select adresse_complete from adresse.point_adresse WHERE id_point=1"
+        )
+        self.cursor.execute(sql)
+        self.assertTupleEqual(("1 Chemin des Cauterets",), self.cursor.fetchone())

--- a/gestion_base_adresse/test/test_execute_functions.py
+++ b/gestion_base_adresse/test/test_execute_functions.py
@@ -479,3 +479,38 @@ class TestSqlFunctions(DatabaseTestCase):
         )
         self.cursor.execute(sql)
         self.assertTupleEqual(("1 Chemin des Cauterets",), self.cursor.fetchone())
+
+    def test_calcul_num_adr_voie_complexe(self):
+        """
+        Test de la numérotation sur une voie complexe
+        La voie 2, Route d'Arromanche présente des virages
+        Le calcul des numéros peut-en être affecté
+        """
+        # Suppression des points pour pouvoir tout tester
+        sql = "TRUNCATE TABLE adresse.point_adresse RESTART IDENTITY"
+        self.cursor.execute(sql)
+
+        # Test ajout point impair
+        # Premier point, test d'égalité à 1
+        sql = (
+            "select num, suffixe from adresse.calcul_num_adr(ST_geomfromtext("
+            "'POINT(428237 6922087)', 2154))"
+        )
+        self.cursor.execute(sql)
+        self.assertTupleEqual((1, None), self.cursor.fetchone())
+        # Insertion du point
+        sql = (
+            "INSERT INTO adresse.point_adresse(numero, suffixe, geom) select num, suffixe,"
+            "ST_geomfromtext('POINT(428310 6922058)', 2154) "
+            "from adresse.calcul_num_adr(ST_geomfromtext('POINT(428237 6922087)', 2154))"
+        )
+        self.cursor.execute(sql)
+
+        # Test ajout point pair
+        # Premier point, test d'égalité à 2
+        sql = (
+            "select num, suffixe from adresse.calcul_num_adr(ST_geomfromtext("
+            "'POINT(429148 6921624)', 2154))"
+        )
+        self.cursor.execute(sql)
+        self.assertTupleEqual((2, None), self.cursor.fetchone())


### PR DESCRIPTION
L'identifiant de voie n'était pas assez utiliser dans les fonctions de calcul des numéros d'adresse.