### PR TITLE
SQL: Fournir la voie lors du calcul numérique

### DIFF
--- a/gestion_base_adresse/install/sql/adresse/10_FUNCTION.sql
+++ b/gestion_base_adresse/install/sql/adresse/10_FUNCTION.sql
@@ -36,6 +36,11 @@ BEGIN
     -- Get idvoie
     SELECT adresse.get_id_voie(pgeom) into idvoie;
 
+    -- Aucune voie dévérouillée trouvée
+    IF idvoie IS NULL THEN
+        return query SELECT numc, s, idvoie;
+    END IF;
+
     SELECT adresse.calcul_point_position(adresse.calcul_segment_proche(geom, pgeom),pgeom ) into isleft
     FROM adresse.voie
     WHERE statut_voie_num IS FALSE AND id_voie=idvoie;
@@ -129,6 +134,11 @@ BEGIN
 
     -- Get idvoie
     SELECT adresse.get_id_voie(pgeom) into idvoie;
+
+    -- Aucune voie dévérouillée trouvée
+    IF idvoie IS NULL THEN
+        return query SELECT numc, res, idvoie;
+    END IF;
 
     SELECT v.sens_numerotation into sens FROM adresse.voie v WHERE v.id_voie = idvoie;
 

--- a/gestion_base_adresse/install/sql/adresse/10_FUNCTION.sql
+++ b/gestion_base_adresse/install/sql/adresse/10_FUNCTION.sql
@@ -17,7 +17,7 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 -- calcul_num_adr(public.geometry)
-CREATE FUNCTION adresse.calcul_num_adr(pgeom public.geometry) RETURNS TABLE(num integer, suffixe text)
+CREATE FUNCTION adresse.calcul_num_adr(pgeom public.geometry) RETURNS TABLE(num integer, suffixe text, voie integer)
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -107,13 +107,13 @@ BEGIN
         END IF;
     END IF;
 
-    return query SELECT numc, s;
+    return query SELECT numc, s, idvoie;
 END;
 $$;
 
 
 -- calcul_num_metrique(public.geometry)
-CREATE FUNCTION adresse.calcul_num_metrique(pgeom public.geometry) RETURNS TABLE(num integer, suffixe text)
+CREATE FUNCTION adresse.calcul_num_metrique(pgeom public.geometry) RETURNS TABLE(num integer, suffixe text, voie integer)
     LANGUAGE plpgsql
     AS $$DECLARE
     num integer;
@@ -169,7 +169,7 @@ BEGIN
         num = num +2;
     END LOOP;
 
-   RETURN query SELECT numc, res;
+   RETURN query SELECT numc, res, idvoie;
 END;
 $$;
 

--- a/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
+++ b/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
@@ -21,6 +21,11 @@ BEGIN
     -- Get idvoie
     SELECT adresse.get_id_voie(pgeom) into idvoie;
 
+    -- Aucune voie dévérouillée trouvée
+    IF idvoie IS NULL THEN
+        return query SELECT numc, s, idvoie;
+    END IF;
+
     SELECT adresse.calcul_point_position(adresse.calcul_segment_proche(geom, pgeom),pgeom ) into isleft
     FROM adresse.voie
     WHERE statut_voie_num IS FALSE AND id_voie=idvoie;
@@ -115,6 +120,11 @@ BEGIN
 
     -- Get idvoie
     SELECT adresse.get_id_voie(pgeom) into idvoie;
+
+    -- Aucune voie dévérouillée trouvée
+    IF idvoie IS NULL THEN
+        return query SELECT numc, res, idvoie;
+    END IF;
 
     SELECT v.sens_numerotation into sens FROM adresse.voie v WHERE v.id_voie = idvoie;
 

--- a/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
+++ b/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.3.0.sql
@@ -1,6 +1,8 @@
 BEGIN;
 
-CREATE OR REPLACE FUNCTION adresse.calcul_num_adr(pgeom public.geometry) RETURNS TABLE(num integer, suffixe text)
+-- calcul_num_adr(public.geometry)
+DROP FUNCTION IF EXISTS adresse.calcul_num_adr(pgeom public.geometry);
+CREATE OR REPLACE FUNCTION adresse.calcul_num_adr(pgeom public.geometry) RETURNS TABLE(num integer, suffixe text, voie integer)
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -90,12 +92,14 @@ BEGIN
         END IF;
     END IF;
 
-    return query SELECT numc, s;
+    return query SELECT numc, s, idvoie;
 END;
 $$;
 
 
-CREATE OR REPLACE FUNCTION adresse.calcul_num_metrique(pgeom public.geometry) RETURNS TABLE(num integer, suffixe text)
+-- calcul_num_metrique(public.geometry)
+DROP FUNCTION IF EXISTS adresse.calcul_num_metrique(pgeom public.geometry);
+CREATE OR REPLACE FUNCTION adresse.calcul_num_metrique(pgeom public.geometry) RETURNS TABLE(num integer, suffixe text, voie integer)
     LANGUAGE plpgsql
     AS $$DECLARE
     num integer;
@@ -151,7 +155,7 @@ BEGIN
         num = num +2;
     END LOOP;
 
-   RETURN query SELECT numc, res;
+   RETURN query SELECT numc, res, idvoie;
 END;
 $$;
 

--- a/gestion_base_adresse/test/test_execute_functions.py
+++ b/gestion_base_adresse/test/test_execute_functions.py
@@ -191,6 +191,19 @@ class TestSqlFunctions(DatabaseTestCase):
         )
         self.cursor.execute(sql)
 
+        # Vérouillage des voies
+        sql='UPDATE adresse.voie SET statut_voie_num = true'
+        self.cursor.execute(sql)
+
+        # Aucune voie dévérouillée n'est disponible
+        # Aucun numéro d'adresse calculable
+        sql = (
+            "select num, suffixe, voie from adresse.calcul_num_adr(ST_geomfromtext("
+            "'POINT(428310 6922058)', 2154))"
+        )
+        self.cursor.execute(sql)
+        self.assertTupleEqual((None, None, None), self.cursor.fetchone())
+
     def test_calcul_num_metrique(self):
         """Test de la fonction calcul_num_metrique."""
         # Suppression des points pour pouvoir tout tester
@@ -262,6 +275,19 @@ class TestSqlFunctions(DatabaseTestCase):
             "from adresse.calcul_num_metrique(ST_geomfromtext('POINT(428252 6921965)', 2154))"
         )
         self.cursor.execute(sql)
+
+        # Vérouillage des voies
+        sql='UPDATE adresse.voie SET statut_voie_num = true'
+        self.cursor.execute(sql)
+
+        # Aucune voie dévérouillée n'est disponible
+        # Aucun numéro d'adresse calculable
+        sql = (
+            "select num, suffixe, voie from adresse.calcul_num_metrique(ST_geomfromtext("
+            "'POINT(428310 6922058)', 2154))"
+        )
+        self.cursor.execute(sql)
+        self.assertTupleEqual((None, None, None), self.cursor.fetchone())
 
     def test_multiple_voie_unlock(self):
         """Test d'ajout de point avec plusieurs voies déverrouillées"""

--- a/gestion_base_adresse/test/test_execute_functions.py
+++ b/gestion_base_adresse/test/test_execute_functions.py
@@ -44,14 +44,15 @@ class TestSqlFunctions(DatabaseTestCase):
         # Test ajout point impair
         # Premier point, test d'égalité à 1
         sql = (
-            "select num, suffixe from adresse.calcul_num_adr(ST_geomfromtext("
+            "select num, suffixe, voie from adresse.calcul_num_adr(ST_geomfromtext("
             "'POINT(428310 6922058)', 2154))"
         )
         self.cursor.execute(sql)
-        self.assertTupleEqual((1, None), self.cursor.fetchone())
+        self.assertTupleEqual((1, None, 3), self.cursor.fetchone())
         # Insertion du point
         sql = (
-            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) select num, suffixe, 3,"
+            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) "
+            "SELECT num, suffixe, voie,"
             "ST_geomfromtext('POINT(428310 6922058)', 2154) "
             "from adresse.calcul_num_adr(ST_geomfromtext('POINT(428310 6922058)', 2154))"
         )
@@ -66,14 +67,15 @@ class TestSqlFunctions(DatabaseTestCase):
 
         # Deuxième point placé après le premier, test d'égalité à 3
         sql = (
-            "select num, suffixe from adresse.calcul_num_adr(ST_geomfromtext("
+            "select num, suffixe, voie from adresse.calcul_num_adr(ST_geomfromtext("
             "'POINT(428106 6922255)', 2154))"
         )
         self.cursor.execute(sql)
-        self.assertTupleEqual((3, None), self.cursor.fetchone())
+        self.assertTupleEqual((3, None, 3), self.cursor.fetchone())
         # Insertion du point
         sql = (
-            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) select num, suffixe, 3,"
+            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) "
+            "SELECT num, suffixe, voie,"
             "ST_geomfromtext('POINT(428106 6922255)', 2154) "
             "from adresse.calcul_num_adr(ST_geomfromtext('POINT(428106 6922255)', 2154))"
         )
@@ -81,14 +83,15 @@ class TestSqlFunctions(DatabaseTestCase):
 
         # Troisième point placé entre les deux premiers, test d'égalité à 1bis
         sql = (
-            "select num, suffixe from adresse.calcul_num_adr(ST_geomfromtext("
+            "select num, suffixe, voie from adresse.calcul_num_adr(ST_geomfromtext("
             "'POINT(428198 6922157)', 2154))"
         )
         self.cursor.execute(sql)
-        self.assertTupleEqual((1, "bis"), self.cursor.fetchone())
+        self.assertTupleEqual((1, "bis", 3), self.cursor.fetchone())
         # Insertion du point
         sql = (
-            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) select num, suffixe, 3,"
+            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) "
+            "SELECT num, suffixe, voie,"
             "ST_geomfromtext('POINT(428198 6922157)', 2154) "
             "from adresse.calcul_num_adr(ST_geomfromtext('POINT(428198 6922157)', 2154))"
         )
@@ -97,14 +100,15 @@ class TestSqlFunctions(DatabaseTestCase):
         # Test d'ajout des points Pair
         # Premier point, test d'égalité à 2
         sql = (
-            "select num, suffixe from adresse.calcul_num_adr(ST_geomfromtext("
+            "select num, suffixe, voie from adresse.calcul_num_adr(ST_geomfromtext("
             "'POINT(428226 6922001)', 2154))"
         )
         self.cursor.execute(sql)
-        self.assertTupleEqual((2, None), self.cursor.fetchone())
+        self.assertTupleEqual((2, None, 3), self.cursor.fetchone())
         # Insertion du point
         sql = (
-            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) select num, suffixe, 3,"
+            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) "
+            "SELECT num, suffixe, voie,"
             "ST_geomfromtext('POINT(428226 6922001)', 2154) "
             "from adresse.calcul_num_adr(ST_geomfromtext('POINT(428226 6922001)', 2154))"
         )
@@ -112,14 +116,15 @@ class TestSqlFunctions(DatabaseTestCase):
 
         # Deuxième point placé après le premier, test d'égalité à 4
         sql = (
-            "select num, suffixe from adresse.calcul_num_adr(ST_geomfromtext("
+            "select num, suffixe, voie from adresse.calcul_num_adr(ST_geomfromtext("
             "'POINT(427937 6922173)', 2154))"
         )
         self.cursor.execute(sql)
-        self.assertTupleEqual((4, None), self.cursor.fetchone())
+        self.assertTupleEqual((4, None, 3), self.cursor.fetchone())
         # Insertion du point
         sql = (
-            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) select num, suffixe, 3,"
+            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) "
+            "SELECT num, suffixe, voie,"
             "ST_geomfromtext('POINT(427937 6922173)', 2154) "
             "from adresse.calcul_num_adr(ST_geomfromtext('POINT(427937 6922173)', 2154))"
         )
@@ -127,14 +132,15 @@ class TestSqlFunctions(DatabaseTestCase):
 
         # Troisième point entre les deux autres, test d'égalité à 2bis
         sql = (
-            "select num, suffixe from adresse.calcul_num_adr(ST_geomfromtext("
+            "select num, suffixe, voie from adresse.calcul_num_adr(ST_geomfromtext("
             "'POINT(428035 6922078)', 2154))"
         )
         self.cursor.execute(sql)
-        self.assertTupleEqual((2, "bis"), self.cursor.fetchone())
+        self.assertTupleEqual((2, "bis", 3), self.cursor.fetchone())
         # Insertion du point
         sql = (
-            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) select num, suffixe, 3,"
+            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) "
+            "SELECT num, suffixe, voie,"
             "ST_geomfromtext('POINT(428035 6922078)', 2154) "
             "from adresse.calcul_num_adr(ST_geomfromtext('POINT(428035 6922078)', 2154))"
         )
@@ -147,14 +153,15 @@ class TestSqlFunctions(DatabaseTestCase):
 
         # Premier point, test d'égalité à 2
         sql = (
-            "select num, suffixe from adresse.calcul_num_adr(ST_geomfromtext("
+            "select num, suffixe, voie from adresse.calcul_num_adr(ST_geomfromtext("
             "'POINT(428226 6922001)', 2154))"
         )
         self.cursor.execute(sql)
-        self.assertTupleEqual((2, None), self.cursor.fetchone())
+        self.assertTupleEqual((2, None, 3), self.cursor.fetchone())
         # Insertion du point
         sql = (
-            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) select num, suffixe, 3,"
+            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) "
+            "SELECT num, suffixe, voie,"
             "ST_geomfromtext('POINT(428226 6922001)', 2154) "
             "from adresse.calcul_num_adr(ST_geomfromtext('POINT(428226 6922001)', 2154))"
         )
@@ -170,14 +177,15 @@ class TestSqlFunctions(DatabaseTestCase):
 
         # Troisime point placé après le deuxième, test d'égalité à 4
         sql = (
-            "select num, suffixe from adresse.calcul_num_adr(ST_geomfromtext("
+            "select num, suffixe, voie from adresse.calcul_num_adr(ST_geomfromtext("
             "'POINT(427937 6922173)', 2154))"
         )
         self.cursor.execute(sql)
-        self.assertTupleEqual((4, None), self.cursor.fetchone())
+        self.assertTupleEqual((4, None, 3), self.cursor.fetchone())
         # Insertion du point
         sql = (
-            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) select num, suffixe, 3,"
+            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) "
+            "SELECT num, suffixe, voie,"
             "ST_geomfromtext('POINT(427937 6922173)', 2154) "
             "from adresse.calcul_num_adr(ST_geomfromtext('POINT(427937 6922173)', 2154))"
         )
@@ -192,14 +200,15 @@ class TestSqlFunctions(DatabaseTestCase):
         # Test ajout point impair
         # Premier point, test d'égalité à 1997
         sql = (
-            "select num, suffixe from adresse.calcul_num_metrique(ST_geomfromtext("
+            "select num, suffixe, voie from adresse.calcul_num_metrique(ST_geomfromtext("
             "'POINT(428310 6922058)', 2154))"
         )
         self.cursor.execute(sql)
-        self.assertTupleEqual((1997, None), self.cursor.fetchone())
+        self.assertTupleEqual((1997, None, 3), self.cursor.fetchone())
         # Insertion du point
         sql = (
-            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) select num, suffixe, 3,"
+            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) "
+            "SELECT num, suffixe, voie,"
             "ST_geomfromtext('POINT(428310 6922058)', 2154) "
             "from adresse.calcul_num_metrique(ST_geomfromtext('POINT(428310. 6922058.)', 2154))"
         )
@@ -207,14 +216,15 @@ class TestSqlFunctions(DatabaseTestCase):
 
         # Deuxième point placé sur le même que le premier, test d'égalité à 1997bis
         sql = (
-            "select num, suffixe from adresse.calcul_num_metrique(ST_geomfromtext("
+            "select num, suffixe, voie from adresse.calcul_num_metrique(ST_geomfromtext("
             "'POINT(428310 6922058)', 2154))"
         )
         self.cursor.execute(sql)
-        self.assertTupleEqual((1997, "bis"), self.cursor.fetchone())
+        self.assertTupleEqual((1997, "bis", 3), self.cursor.fetchone())
         # Insertion du point
         sql = (
-            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) select num, suffixe, 3,"
+            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) "
+            "SELECT num, suffixe, voie,"
             "ST_geomfromtext('POINT(428310 6922058)', 2154) "
             "from adresse.calcul_num_metrique(ST_geomfromtext('POINT(428310 6922058)', 2154))"
         )
@@ -223,14 +233,15 @@ class TestSqlFunctions(DatabaseTestCase):
         # Test ajout point Pair
         # Premier point, test d'égalité à 1992
         sql = (
-            "select num, suffixe from adresse.calcul_num_metrique(ST_geomfromtext("
+            "select num, suffixe, voie from adresse.calcul_num_metrique(ST_geomfromtext("
             "'POINT(428252 6921965)', 2154))"
         )
         self.cursor.execute(sql)
-        self.assertTupleEqual((1992, None), self.cursor.fetchone())
+        self.assertTupleEqual((1992, None, 3), self.cursor.fetchone())
         # Insertion du point
         sql = (
-            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) select num, suffixe, 3,"
+            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) "
+            "SELECT num, suffixe, voie,"
             "ST_geomfromtext('POINT(428252 6921965)', 2154) "
             "from adresse.calcul_num_metrique(ST_geomfromtext('POINT(428252 6921965)', 2154))"
         )
@@ -238,14 +249,15 @@ class TestSqlFunctions(DatabaseTestCase):
 
         # Deuxième point placé sur le même que le premier, test d'égalité à 1992bis
         sql = (
-            "select num, suffixe from adresse.calcul_num_metrique(ST_geomfromtext("
+            "select num, suffixe, voie from adresse.calcul_num_metrique(ST_geomfromtext("
             "'POINT(428252 6921965)', 2154))"
         )
         self.cursor.execute(sql)
-        self.assertTupleEqual((1992, "bis"), self.cursor.fetchone())
+        self.assertTupleEqual((1992, "bis", 3), self.cursor.fetchone())
         # Insertion du point
         sql = (
-            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) select num, suffixe, 3,"
+            "INSERT INTO adresse.point_adresse(numero, suffixe, id_voie, geom) "
+            "SELECT num, suffixe, voie,"
             "ST_geomfromtext('POINT(428252 6921965)', 2154) "
             "from adresse.calcul_num_metrique(ST_geomfromtext('POINT(428252 6921965)', 2154))"
         )


### PR DESCRIPTION
Le numéro est calculé par rapport à une voie, il est utile de pouvoir récupérer la voie utilisé pour calculer le numéro.