### PR TITLE
Mise à jour trigger lieux_dits

### DIFF
--- a/gestion_base_adresse/install/sql/adresse/10_FUNCTION.sql
+++ b/gestion_base_adresse/install/sql/adresse/10_FUNCTION.sql
@@ -282,6 +282,23 @@ END;
 $$;
 
 
+-- edit_com_lieux_dits()
+CREATE FUNCTION adresse.edit_com_lieux_dits() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+BEGIN
+    SELECT c.id_com into NEW.id_com
+    FROM adresse.commune c 
+	WHERE ST_DWithin(NEW.geom, c.geom, 0.01);
+
+	NEW.numero = 99999 ;
+	NEW.date_der_maj = NOW();
+RETURN NEW;
+END;
+$$;
+
+
 -- edit_lieux_dits()
 CREATE FUNCTION adresse.edit_lieux_dits() RETURNS trigger
     LANGUAGE plpgsql
@@ -442,27 +459,6 @@ DECLARE
 BEGIN
     NEW.id_parcelle = (SELECT p.fid FROM adresse.parcelle p WHERE ST_intersects(NEW.geom, p.geom));
     RETURN NEW;
-END;
-$$;
-
-
--- lieux_dits()
-CREATE FUNCTION adresse.edit_com_lieux_dits() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
-DECLARE
-BEGIN
-    SELECT c.id_com into NEW.id_com
-    FROM adresse.commune c 
-	WHERE ST_DWithin(NEW.geom, c.geom, 0.01);
-
-	SELECT d.id_com_del into NEW.id_com_del
-    FROM adresse.commune_deleguee d
-	WHERE ST_DWithin(NEW.geom, d.geom, 0.01);
-
-	NEW.numero = 99999 ;
-	NEW.date_der_maj = NOW();
-RETURN NEW;
 END;
 $$;
 

--- a/gestion_base_adresse/install/sql/adresse/50_TRIGGER.sql
+++ b/gestion_base_adresse/install/sql/adresse/50_TRIGGER.sql
@@ -46,7 +46,7 @@ CREATE TRIGGER get_parcelle BEFORE INSERT OR UPDATE ON adresse.point_adresse FOR
 
 
 -- lieux_dits infos_lieux_dits
-CREATE TRIGGER infos_lieux_dits BEFORE INSERT OR UPDATE ON adresse.lieux_dits FOR EACH ROW EXECUTE PROCEDURE adresse.lieux_dits();
+CREATE TRIGGER infos_lieux_dits BEFORE INSERT OR UPDATE ON adresse.lieux_dits FOR EACH ROW EXECUTE PROCEDURE adresse.edit_com_lieux_dits();
 
 
 -- point_adresse nb_point

--- a/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.9.0.sql
+++ b/gestion_base_adresse/install/sql/upgrade/upgrade_to_0.9.0.sql
@@ -183,7 +183,11 @@ $$;
 CREATE TRIGGER edit_lieux_dits_from_view INSTEAD OF INSERT OR DELETE OR UPDATE ON adresse.v_lieux_dits FOR EACH ROW EXECUTE PROCEDURE adresse.edit_lieux_dits();
 
 
--- lieux_dits()
+-- function edit_com_lieux_dits()
+
+DROP TRIGGER IF EXISTS infos_lieux_dits ON adresse.lieux_dits;
+
+DROP FUNCTION adresse.lieux_dits();
 
 CREATE OR REPLACE FUNCTION adresse.edit_com_lieux_dits() RETURNS trigger
     LANGUAGE plpgsql
@@ -194,15 +198,12 @@ BEGIN
     FROM adresse.commune c 
 	WHERE ST_DWithin(NEW.geom, c.geom, 0.01);
 
-	SELECT d.id_com_del into NEW.id_com_del
-    FROM adresse.commune_deleguee d
-	WHERE ST_DWithin(NEW.geom, d.geom, 0.01);
-
 	NEW.numero = 99999 ;
 	NEW.date_der_maj = NOW();
 RETURN NEW;
 END;
 $$;
 
+CREATE TRIGGER infos_lieux_dits BEFORE INSERT OR UPDATE ON adresse.lieux_dits FOR EACH ROW EXECUTE PROCEDURE adresse.edit_com_lieux_dits();
 
 COMMIT;

--- a/gestion_base_adresse/test/test_execute_functions.py
+++ b/gestion_base_adresse/test/test_execute_functions.py
@@ -426,7 +426,7 @@ class TestSqlFunctions(DatabaseTestCase):
         self.cursor.execute(sql)
         self.assertTupleEqual((753, None), self.cursor.fetchone())
 
-    def test_id_commune(self):
+    def test_id_commune_point_adresse(self):
         """Test si l'id de la commune et
         Présent lors de l'ajout d'un point"""
 
@@ -439,6 +439,22 @@ class TestSqlFunctions(DatabaseTestCase):
 
         sql = (
             "SELECT id_commune FROM adresse.point_adresse WHERE id_point = 100"
+        )
+        self.cursor.execute(sql)
+        self.assertEqual((4,), self.cursor.fetchone())
+
+    def test_id_commune_lieux_dits(self):
+        """Test si l'id de la commune et
+        Présent lors de l'ajout d'un lieu dit"""
+
+        sql = (
+            "INSERT INTO adresse.lieux_dits(id_ld, numero, nom_ld, integration_ban, geom) "
+            "VALUES(100, 2, 'Test lieux dits', false, ST_geomfromtext('POINT(428310 6922058)', 2154));"
+        )
+        self.cursor.execute(sql)
+
+        sql = (
+            "SELECT id_com FROM adresse.lieux_dits WHERE id_ld = 100"
         )
         self.cursor.execute(sql)
         self.assertEqual((4,), self.cursor.fetchone())


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Modification du trigger lieux_dits qui modifie les identifiants de `commune` et `commune_deleguee`. il fallait retirer la modification des noms que ne sont plus stockés dans `lieux_dits`.
